### PR TITLE
support for .s extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"languages": [{
 			"id": "asm",
 			"aliases": ["x86 and x86_64 Assembly", "asm"],
-			"extensions": [".asm",".nasm",".yasm",".inc"]
+			"extensions": [".asm",".nasm",".yasm",".inc",".s"]
 		}],
 		"grammars": [{
 			"language": "asm",


### PR DESCRIPTION
Some compilers default to `.s` as the extension for assembly files. For example, `gcc -S input.c` will produce `input.s`.
