### PR TITLE
Support for single line GAS style comment

### DIFF
--- a/syntaxes/language-x86_64-assembly.tmLanguage
+++ b/syntaxes/language-x86_64-assembly.tmLanguage
@@ -55,7 +55,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(;|(^|\s)#\s).*$</string>
+					<string>(;|\/\/|(^|\s)#\s).*$</string>
 					<key>name</key>
 					<string>comment.line</string>
 				</dict>


### PR DESCRIPTION
Support for single line GAS style comment (`//`).