### PR TITLE
Add short for syntax highlighting

### DIFF
--- a/syntaxes/language-x86_64-assembly.tmLanguage
+++ b/syntaxes/language-x86_64-assembly.tmLanguage
@@ -1880,7 +1880,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?i)\b(?:strict|nosplit|near|far|abs|rel)\b</string>
+					<string>(?i)\b(?:strict|nosplit|short|near|far|abs|rel)\b</string>
 					<key>name</key>
 					<string>storage.modifier.asm.x86_64</string>
 				</dict>


### PR DESCRIPTION
Although I am not clear where it is outlined in the documentation, `short` is possible similar to `near`.
> A near jump where the jump range is limited to –128 to +127
The above quote is from [here](https://www.felixcloutier.com/x86/jmp).

Please correct me if this is incorrect, no longer supported, or ect.